### PR TITLE
Potential fix for code scanning alert no. 3: Replacement of a substring with itself

### DIFF
--- a/lmo/addon/classlib/doc/media/lib/classTree.js
+++ b/lmo/addon/classlib/doc/media/lib/classTree.js
@@ -437,8 +437,8 @@ WebFXTreeItem.prototype.toString = function (nItem, nItemCount) {
 	}
 	else if (!this.icon) { this.icon = webFXTreeConfig.fileIcon; }
 	var label = this.text;
-	label = label.replace('<', '<');
-	label = label.replace('>', '>');
+	label = label.replace('<', '&lt;');
+	label = label.replace('>', '&gt;');
 	var str = "<div id=\"" + this.id + "\" ondblclick=\"webFXTreeHandler.toggle(this);\" class=\"webfx-tree-item\" onkeydown=\"return webFXTreeHandler.keydown(this)\">";
 	str += indent;
 	str += "<img id=\"" + this.id + "-plus\" src=\"" + ((this.folder)?((this.open)?((this.parentNode._last)?webFXTreeConfig.lMinusIcon:webFXTreeConfig.tMinusIcon):((this.parentNode._last)?webFXTreeConfig.lPlusIcon:webFXTreeConfig.tPlusIcon)):((this.parentNode._last)?webFXTreeConfig.lIcon:webFXTreeConfig.tIcon)) + "\" onclick=\"webFXTreeHandler.toggle(this);\">"


### PR DESCRIPTION
Potential fix for [https://github.com/babbisch/LMO_PHP8/security/code-scanning/3](https://github.com/babbisch/LMO_PHP8/security/code-scanning/3)

To fix the problem, we need to replace the `<` character with its HTML escape sequence `&lt;` and the `>` character with `&gt;`. This ensures that the characters are properly escaped in the generated HTML, preventing potential issues with HTML rendering or injection attacks.

- Update the replacement string on line 440 to replace `<` with `&lt;`.
- Update the replacement string on line 441 to replace `>` with `&gt;`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
